### PR TITLE
Remove:Schedule_basesテーブルのPattrenカラムのユニーク制約を削除しました。

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.4-x86_64-linux)
+      racc (~> 1.4)
     oauth (0.5.10)
     oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
@@ -282,6 +284,8 @@ GEM
     strscan (3.0.1)
     tailwindcss-rails (2.0.8-x86_64-darwin)
       railties (>= 6.0.0)
+    tailwindcss-rails (2.0.8-x86_64-linux)
+      railties (>= 6.0.0)
     thor (1.2.1)
     timeout (0.2.0)
     turbo-rails (1.0.1)
@@ -305,6 +309,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   active_hash

--- a/app/models/schedule_basis.rb
+++ b/app/models/schedule_basis.rb
@@ -3,5 +3,5 @@ class ScheduleBasis < ApplicationRecord
   has_many :task_bases, dependent: :destroy
 
   validates :title, presence: true
-  validates :pattren, uniqueness: true, presence: true
+  validates :pattren, presence: true
 end

--- a/db/migrate/20220525000904_delete_pattren_uniq_index_from_schedule_basis.rb
+++ b/db/migrate/20220525000904_delete_pattren_uniq_index_from_schedule_basis.rb
@@ -1,0 +1,5 @@
+class DeletePattrenUniqIndexFromScheduleBasis < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :schedule_bases, :pattren
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_05_16_003409) do
+ActiveRecord::Schema[7.0].define(version: 2022_05_25_000904) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,7 +39,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_05_16_003409) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["pattren"], name: "index_schedule_bases_on_pattren", unique: true
     t.index ["user_id"], name: "index_schedule_bases_on_user_id"
   end
 


### PR DESCRIPTION
https://github.com/KouSei089/a-meta-note/issues/93

上記のissueです。