### PR TITLE
fix:Analysis Feedbackの結果が0の時も表示されてしまうバグを修正しました

### DIFF
--- a/app/controllers/concerns/schedule_module.rb
+++ b/app/controllers/concerns/schedule_module.rb
@@ -64,9 +64,13 @@ module ScheduleModule
                        else
                          task_basis_percent_sum - task_percent_sum
                        end
+      if percent_result == 0
+        next
+      else
+        @percent_results.push(percent_result)
+      end
       @name_results.push(task_categories_sames[0].category_name)
       @color_results.push(task_categories_sames[0].categories[0].color_code)
-      @percent_results.push(percent_result)
       index_num += 1
     end
   end


### PR DESCRIPTION
percent_result == 0かどうかで条件分岐し、0の時はnextで処理を抜ける記述に変更しました。それに伴い、percent_resultの処理が先にできるように、記述を上段に持ってきました。

ブラウザも確認済ですが、ご確認お願いします！